### PR TITLE
chore(deps): upgrade @geist-ui/icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/lib-storage": "3.81.0",
     "@aws-sdk/s3-request-presigner": "3.81.0",
     "@geist-ui/core": "2.3.8",
-    "@geist-ui/icons": "1.0.1",
+    "@geist-ui/icons": "1.0.2",
     "@next-auth/prisma-adapter": "1.0.3",
     "@prisma/client": "3.13.0",
     "@sindresorhus/is": "4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 specifiers:
   '@aws-sdk/abort-controller': ^3.78.0
@@ -6,7 +6,7 @@ specifiers:
   '@aws-sdk/lib-storage': 3.81.0
   '@aws-sdk/s3-request-presigner': 3.81.0
   '@geist-ui/core': 2.3.8
-  '@geist-ui/icons': 1.0.1
+  '@geist-ui/icons': 1.0.2
   '@next-auth/prisma-adapter': 1.0.3
   '@prisma/client': 3.13.0
   '@sindresorhus/is': 4.6.0
@@ -29,16 +29,16 @@ specifiers:
 dependencies:
   '@aws-sdk/abort-controller': 3.78.0
   '@aws-sdk/client-s3': 3.81.0
-  '@aws-sdk/lib-storage': 3.81.0_n265mp6qg7rh3mruguy27tqnwq
+  '@aws-sdk/lib-storage': 3.81.0_6ebdd63fd037e27db2343531afce0db4
   '@aws-sdk/s3-request-presigner': 3.81.0
-  '@geist-ui/core': 2.3.8_sfoxds7t5ydpegc3knd667wn6m
-  '@geist-ui/icons': 1.0.1_react@17.0.2
-  '@next-auth/prisma-adapter': 1.0.3_u3ogd5z4kbwlouborc6ijrqh7m
+  '@geist-ui/core': 2.3.8_react-dom@17.0.2+react@17.0.2
+  '@geist-ui/icons': 1.0.2_4c56d53457fa142df32c829605742487
+  '@next-auth/prisma-adapter': 1.0.3_a6dc61f73c506cb7502e88bc84c607fb
   '@prisma/client': 3.13.0_prisma@3.13.0
   '@sindresorhus/is': 4.6.0
   consola: 2.15.3
-  next: 12.1.5_sfoxds7t5ydpegc3knd667wn6m
-  next-auth: 4.3.4_sfoxds7t5ydpegc3knd667wn6m
+  next: 12.1.5_react-dom@17.0.2+react@17.0.2
+  next-auth: 4.3.4_react-dom@17.0.2+react@17.0.2
   next-connect: 0.12.2
   prisma: 3.13.0
   react: 17.0.2
@@ -49,7 +49,7 @@ devDependencies:
   '@types/react': 17.0.44
   autoprefixer: 10.4.7_postcss@8.4.13
   eslint: 8.14.0
-  eslint-config-next: 12.1.5_ldpv3uesskyaguxpaa56hbtpeu
+  eslint-config-next: 12.1.5_58df5dd09292b00352ef003be3866f25
   postcss: 8.4.13
   tailwindcss: 3.0.24
   typescript: 4.6.4
@@ -470,7 +470,7 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/lib-storage/3.81.0_n265mp6qg7rh3mruguy27tqnwq:
+  /@aws-sdk/lib-storage/3.81.0_6ebdd63fd037e27db2343531afce0db4:
     resolution: {integrity: sha512-yMM/Xuyh5FeVZbTez98Nl2Av8s3O8PkLTWLKeJOhhz0fzvmL3zg024+aMJgy+Jc+N8WfATrtE+2WW1so5gV8uw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -990,7 +990,7 @@ packages:
       - supports-color
     dev: true
 
-  /@geist-ui/core/2.3.8_sfoxds7t5ydpegc3knd667wn6m:
+  /@geist-ui/core/2.3.8_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-OKwGgTA4+fBM41eQbqDoUj4XBycZbYH7Ynrn6LPO5yKX7zeWPu/R7HN3vB4/oHt34VTDQI5sDNb1SirHvNyB5w==}
     peerDependencies:
       react: '>=16.9.0'
@@ -1001,12 +1001,13 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@geist-ui/icons/1.0.1_react@17.0.2:
-    resolution: {integrity: sha512-W+ol1DOk9MNjY9IV0gKbhaKIjif6O+5wxM31CIUUAl6shjRjmwVPxVNFoaVJwiTp0Chp5BQyluHmCWaOOZQCtA==}
+  /@geist-ui/icons/1.0.2_4c56d53457fa142df32c829605742487:
+    resolution: {integrity: sha512-Npfa0NW6fQ31qw/+iMPWbs1hAcJ/3FqBjSLYgEfITDqy/3TJFpFKeVyK04AC/hTmYTsdNruVYczqPNcham5FOQ==}
     peerDependencies:
-      '@geist-ui/react': '>=1.0.0'
+      '@geist-ui/core': '>=1.0.0'
       react: '>=16.13.0'
     dependencies:
+      '@geist-ui/core': 2.3.8_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -1025,14 +1026,14 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@next-auth/prisma-adapter/1.0.3_u3ogd5z4kbwlouborc6ijrqh7m:
+  /@next-auth/prisma-adapter/1.0.3_a6dc61f73c506cb7502e88bc84c607fb:
     resolution: {integrity: sha512-3Lq1cD3ytKM3EGKJZ4UZvlqshLtlPvYxLeCrUV9ifYwYlq51kmDaHjsIawlp8EbH5pE1UhlsvtlXMery7RghtA==}
     peerDependencies:
       '@prisma/client': '>=2.26.0 || >=3'
       next-auth: ^4.0.1
     dependencies:
       '@prisma/client': 3.13.0_prisma@3.13.0
-      next-auth: 4.3.4_sfoxds7t5ydpegc3knd667wn6m
+      next-auth: 4.3.4_react-dom@17.0.2+react@17.0.2
     dev: false
 
   /@next/env/12.1.5:
@@ -1234,7 +1235,7 @@ packages:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
     dev: true
 
-  /@typescript-eslint/parser/5.10.1_t725usgvqspm5woeqpaxbfp2qu:
+  /@typescript-eslint/parser/5.10.1_eslint@8.14.0+typescript@4.6.4:
     resolution: {integrity: sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1722,7 +1723,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-next/12.1.5_ldpv3uesskyaguxpaa56hbtpeu:
+  /eslint-config-next/12.1.5_58df5dd09292b00352ef003be3866f25:
     resolution: {integrity: sha512-P+DCt5ti63KhC0qNLzrAmPcwRGq8pYqgcf/NNr1E+WjCrMkWdCAXkIANTquo+kcO1adR2k1lTo5GCrNUtKy4hQ==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -1734,15 +1735,15 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 12.1.5
       '@rushstack/eslint-patch': 1.0.8
-      '@typescript-eslint/parser': 5.10.1_t725usgvqspm5woeqpaxbfp2qu
+      '@typescript-eslint/parser': 5.10.1_eslint@8.14.0+typescript@4.6.4
       eslint: 8.14.0
       eslint-import-resolver-node: 0.3.4
-      eslint-import-resolver-typescript: 2.4.0_lf4ywoc2hlokojlkywos2ds24a
+      eslint-import-resolver-typescript: 2.4.0_59798b385a3adca7256ac59d2d0e5ae0
       eslint-plugin-import: 2.25.2_eslint@8.14.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.14.0
       eslint-plugin-react: 7.29.1_eslint@8.14.0
       eslint-plugin-react-hooks: 4.3.0_eslint@8.14.0
-      next: 12.1.5_sfoxds7t5ydpegc3knd667wn6m
+      next: 12.1.5_react-dom@17.0.2+react@17.0.2
       typescript: 4.6.4
     transitivePeerDependencies:
       - supports-color
@@ -1762,7 +1763,7 @@ packages:
       resolve: 1.22.0
     dev: true
 
-  /eslint-import-resolver-typescript/2.4.0_lf4ywoc2hlokojlkywos2ds24a:
+  /eslint-import-resolver-typescript/2.4.0_59798b385a3adca7256ac59d2d0e5ae0:
     resolution: {integrity: sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2436,7 +2437,7 @@ packages:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: true
 
-  /next-auth/4.3.4_sfoxds7t5ydpegc3knd667wn6m:
+  /next-auth/4.3.4_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-8dGkNicbxY2BYsJq4uOJIEsGt39wXj5AViTBsVfbRQqtAFmZmXYHutf90VBmobm8rT2+Xl60HDUTkuVVK+x+xw==}
     engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0}
     peerDependencies:
@@ -2466,7 +2467,7 @@ packages:
       trouter: 3.2.0
     dev: false
 
-  /next/12.1.5_sfoxds7t5ydpegc3knd667wn6m:
+  /next/12.1.5_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-YGHDpyfgCfnT5GZObsKepmRnne7Kzp7nGrac07dikhutWQug7hHg85/+sPJ4ZW5Q2pDkb+n0FnmLkmd44htIJQ==}
     engines: {node: '>=12.22.0'}
     hasBin: true


### PR DESCRIPTION
Upgrade `@geist-ui/icons` [1.0.2](https://github.com/geist-org/icons/releases/tag/v1.0.2) to dismiss peer dependency warnings